### PR TITLE
Update url for new api

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -1,6 +1,7 @@
 <?php
 
-  $url = "http://www.bmreports.com/bsp/additional/soapfunctions.php?element=generationbyfueltypetable";
+  #See: https://www.elexonportal.co.uk/SCRIPTING
+  $url = "https://downloads.elexonportal.co.uk/fuel/download/latest?key=ELEXON-BMRS-API-KEY";
 
   $ch = curl_init();
   curl_setopt($ch, CURLOPT_URL,$url);
@@ -11,8 +12,8 @@
   $xml = simplexml_load_string($output);
 
   $len = count($xml->INST->FUEL);
-  
-  
+
+
   $intensity = array(
     "CCGT"=>360,
     "OCGT"=>480,
@@ -28,30 +29,30 @@
     "INTNED"=>550,
     "INTEW"=>450
   );
-  
+
   $co2intensity = 0;
   $totalsupply = 0;
-  
+
   $data = array();
   $values = array();
-    
+
   for ($i=0; $i<$len; $i++) {
     $name = $xml->INST->FUEL[$i]['TYPE']."";
     $val = $xml->INST->FUEL[$i]['VAL']*1.0;
     $pct = $xml->INST->FUEL[$i]['PCT']*0.01;
-    
+
     $co2intensity += $pct*$intensity[$name];
-    
+
     $data["".$name."_val"] = $val;
     $data["".$name."_prc"] = $pct;
     $values[] = $val;
     $totalsupply += $val;
   }
-  
+
   $data["gridintensity"] = $co2intensity / 0.93;
   $data["totalsupply"] = $totalsupply;
   $values[] = $data["gridintensity"];
   $values[] = $data["totalsupply"];
-  
+
   file_get_contents("http://localhost/ukgrid/api.php?q=post&id=1&apikey=MANUAL-WRITE-APIKEY&values=".implode(",",$values));
 


### PR DESCRIPTION
This updates the URL in line with the new Elexon BMRS REST API (although this particular response is not part of the documented API and is a 'Pre-Formatted URL' described here: https://www.elexonportal.co.uk/scripting ) . This data is no longer available without an API key which you can generate for free by going to: https://www.elexonportal.co.uk/registration/newuser .

Once you have generated the API key you need to manually insert it into this file substituting ELEXON-BMRS-API-KEY in the pre-formatted URL. 

The response is the same as the one using the old URL so should work immediately once the URL has been changed and the API key added.